### PR TITLE
NFC session invalidation with error messages

### DIFF
--- a/LibreTransmitter/LibreTransmitterManagerV3.swift
+++ b/LibreTransmitter/LibreTransmitterManagerV3.swift
@@ -237,6 +237,7 @@ public final class LibreTransmitterManagerV3: CGMManager, LibreTransmitterDelega
 
         proxy = LibreTransmitterProxyManager()
         proxy?.delegate = self
+        
     }
 
     deinit {
@@ -275,6 +276,18 @@ public final class LibreTransmitterManagerV3: CGMManager, LibreTransmitterDelega
     var lastDirectUpdate: Date?
 
     internal var countTimesWithoutData: Int = 0
+    
+    func issueTestAlert() {
+        logger.debug("ussuing test alert")
+        delegate.notify { delegate in
+            
+            let foreground = Alert.Content(title: "test", body: "test2", acknowledgeActionButtonLabel: "ok")
+            let background = Alert.Content(title: "backgrounttest", body: "backgroundtest2", acknowledgeActionButtonLabel: "ok")
+            let identifier = Alert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
+            var alert = Alert(identifier: identifier, foregroundContent: foreground, backgroundContent: background, trigger: Alert.Trigger.immediate)
+            delegate?.issueAlert(alert)
+        }
+    }
 
 }
 

--- a/LibreTransmitter/LibreTransmitterManagerV3.swift
+++ b/LibreTransmitter/LibreTransmitterManagerV3.swift
@@ -277,17 +277,6 @@ public final class LibreTransmitterManagerV3: CGMManager, LibreTransmitterDelega
 
     internal var countTimesWithoutData: Int = 0
     
-    func issueTestAlert() {
-        logger.debug("ussuing test alert")
-        delegate.notify { delegate in
-            
-            let foreground = Alert.Content(title: "test", body: "test2", acknowledgeActionButtonLabel: "ok")
-            let background = Alert.Content(title: "backgrounttest", body: "backgroundtest2", acknowledgeActionButtonLabel: "ok")
-            let identifier = Alert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
-            var alert = Alert(identifier: identifier, foregroundContent: foreground, backgroundContent: background, trigger: Alert.Trigger.immediate)
-            delegate?.issueAlert(alert)
-        }
-    }
 
 }
 

--- a/LibreTransmitterUI/Views/Setup/Libre2DirectSetup.swift
+++ b/LibreTransmitterUI/Views/Setup/Libre2DirectSetup.swift
@@ -59,7 +59,7 @@ struct Libre2DirectSetup: View {
         service.pairSensor()
 
     }
-
+    
     func receivePairingInfo(_ info: SensorPairingInfo) {
 
         print("Received Pairinginfo: \(String(describing: info))")
@@ -109,38 +109,6 @@ struct Libre2DirectSetup: View {
         }// .accentColor(.red)
     }
     
-    var pairingInfoSection: some View {
-        Section(header: Text("Pairinginfo")) {
-            if showPairingInfo {
-
-                SettingsItem(title: "UUID", detail: Binding<String>(get: {
-                    pairingInfo.uuid.hex
-                }, set: { _ in
-                    // not used
-                }))
-
-                SettingsItem(title: "PatchInfo", detail: Binding<String>(get: {
-                    pairingInfo.patchInfo.hex
-                }, set: { _ in
-                    // not used
-                }))
-
-                SettingsItem(title: "Calibrationinfo", detail: Binding<String>(get: {
-                    if let c = pairingInfo.calibrationData {
-                        return"\(c.i1),\(c.i2), \(c.i3), \(c.i4), \(c.i5), \(c.i6)"
-
-                    }
-                    return "Unknown"
-                }, set: { _ in
-                    // not used
-                }))
-
-            } else {
-                Text("Not paired yet")
-            }
-
-        }
-    }
     
     var body : some View {
         GuidePage(content: {
@@ -169,6 +137,7 @@ struct Libre2DirectSetup: View {
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: cancelButton)  // the pair button does the save process for us! //, trailing: saveButton)
         .onReceive(service.publisher, perform: receivePairingInfo)
+        //.onReceive(service.errorPublisher, perform: receiveError)
         .alert(item: $presentableStatus) { status in
             Alert(title: Text(status.title), message: Text(status.message), dismissButton: .default(Text("Got it!")))
         


### PR DESCRIPTION
We should decide if the error messages should be displayed by the IOS NFC scanning ui, or in a popup after the scanning has completed/failed. This implementation facilitates both approaches but lets IOS's NFC scanning ui show the error message per default.

